### PR TITLE
Add Gin based WebSocket server

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,4 +2,7 @@ module intro-quiz/backend
 
 go 1.20
 
-require github.com/gorilla/websocket v1.5.0
+require (
+	github.com/gin-gonic/gin v1.9.0
+	github.com/gorilla/websocket v1.5.0
+)

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,37 +1,45 @@
 package main
 
 import (
-    "log"
-    "net/http"
+	"log"
+	"net/http"
 
-    "github.com/gorilla/websocket"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 )
 
-var upgrader = websocket.Upgrader{}
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
 
-func echo(w http.ResponseWriter, r *http.Request) {
-    conn, err := upgrader.Upgrade(w, r, nil)
-    if err != nil {
-        log.Print("upgrade:", err)
-        return
-    }
-    defer conn.Close()
-    for {
-        mt, message, err := conn.ReadMessage()
-        if err != nil {
-            log.Println("read:", err)
-            break
-        }
-        log.Printf("recv: %s", message)
-        if err = conn.WriteMessage(mt, message); err != nil {
-            log.Println("write:", err)
-            break
-        }
-    }
+func wsHandler(c *gin.Context) {
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Printf("upgrade: %v", err)
+		return
+	}
+	log.Printf("client connected: %s", conn.RemoteAddr())
+	defer func() {
+		log.Printf("client disconnected: %s", conn.RemoteAddr())
+		conn.Close()
+	}()
+	for {
+		mt, message, err := conn.ReadMessage()
+		if err != nil {
+			log.Printf("read: %v", err)
+			break
+		}
+		log.Printf("recv: %s", message)
+		if err = conn.WriteMessage(mt, message); err != nil {
+			log.Printf("write: %v", err)
+			break
+		}
+	}
 }
 
 func main() {
-    http.HandleFunc("/ws", echo)
-    log.Println("Listening on :8080")
-    log.Fatal(http.ListenAndServe(":8080", nil))
+	router := gin.Default()
+	router.GET("/ws", wsHandler)
+	log.Println("Listening on :8080")
+	log.Fatal(router.Run(":8080"))
 }


### PR DESCRIPTION
## Summary
- implement WebSocket server in `backend/main.go` using Gin
- add Gin dependency in `backend/go.mod`

## Testing
- `go vet ./...` *(fails: missing go.sum due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6850af4203a48321a6f29639027aa34e