### PR TITLE
Fix backend GLIBC issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ docker build -t intro-quiz-backend ./backend
 docker run -p 8080:8080 intro-quiz-backend
 ```
 
+バックエンドイメージは静的リンクされたバイナリを生成するため、追加のライブラリを必要としません。
+これは GLIBC のバージョン違いによる起動失敗を防ぐためです。
+
 ### docker-compose を使った起動
 
 `docker-compose.yml` が用意されているため、ルートディレクトリで次のコマンドを実行するだけでフロントエンドとバックエンドの両方を起動できます。

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 # Build stage
 FROM golang:1.21 AS build
+# Build a static binary to avoid GLIBC version mismatch
+ENV CGO_ENABLED=0
 WORKDIR /app
 COPY go.mod .
 COPY go.sum .
@@ -8,7 +10,7 @@ COPY main.go .
 RUN go build -o server
 
 # Run stage
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/static
 WORKDIR /app
 COPY --from=build /app/server ./
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- build the Go backend statically to avoid GLIBC mismatch
- document the static build in README

## Testing
- `go test ./...` *(backend, no tests)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6850bc1a5a208321b32cbbedaf96861d