### PR TITLE
Add YouTube playlist fetch example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+YOUTUBE_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 *.test
 *.out
 .DS_Store
+
+.env

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module intro-quiz
+
+go 1.23.8
+
+require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+type playlistItemsResponse struct {
+	Items []struct {
+		Snippet struct {
+			Title string `json:"title"`
+		} `json:"snippet"`
+	} `json:"items"`
+}
+
+func main() {
+	// Load environment variables from .env file
+	if err := godotenv.Load(); err != nil {
+		log.Fatalf("Error loading .env file: %v", err)
+	}
+
+	apiKey := os.Getenv("YOUTUBE_API_KEY")
+	if apiKey == "" {
+		log.Fatal("YOUTUBE_API_KEY not set")
+	}
+
+	playlistID := "PLBCF2DAC6FFB574DE"
+
+	url := fmt.Sprintf(
+		"https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=5&playlistId=%s&key=%s",
+		playlistID,
+		apiKey,
+	)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatalf("Failed to request API: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Fatalf("API request failed with status: %s", resp.Status)
+	}
+
+	var data playlistItemsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		log.Fatalf("Failed to parse response: %v", err)
+	}
+
+	for i, item := range data.Items {
+		fmt.Printf("%d: %s\n", i+1, item.Snippet.Title)
+	}
+}


### PR DESCRIPTION
## Summary
- add `.env.example` with YouTube API key placeholder
- ignore `.env` in `.gitignore`
- implement a small Go program to fetch playlist video titles using YouTube Data API
- add `go.mod` and `go.sum` for dependency management

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6850edc9a0548321bcef101469307b0a