### PR TITLE
Add YouTube Data API test endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 *.test
 *.out
 .DS_Store
+backend/.env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the Intro-Quiz backend
+YOUTUBE_API_KEY=your_api_key_here
+PORT=8080

--- a/backend/cmd/intro-quiz/main.go
+++ b/backend/cmd/intro-quiz/main.go
@@ -4,12 +4,15 @@ import (
 	"log"
 
 	"github.com/gin-gonic/gin"
+	"intro-quiz/backend/internal/config"
 	"intro-quiz/backend/internal/handler"
 )
 
 func main() {
+	config.LoadEnv()
 	router := gin.Default()
 	router.GET("/ws", handler.WSHandler)
+	router.GET("/api/youtube/test", handler.YouTubeTestHandler)
 	log.Println("Listening on :8080")
 	log.Fatal(router.Run(":8080"))
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/joho/godotenv v1.5.1
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -26,6 +26,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=

--- a/backend/internal/config/env.go
+++ b/backend/internal/config/env.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"log"
+
+	"github.com/joho/godotenv"
+)
+
+// LoadEnv loads environment variables from a .env file.
+func LoadEnv() {
+	if err := godotenv.Load(); err != nil {
+		log.Println("no .env file found")
+	}
+}

--- a/backend/internal/handler/youtube.go
+++ b/backend/internal/handler/youtube.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"intro-quiz/backend/internal/service"
+)
+
+// YouTubeTestHandler returns the first video title of a fixed playlist.
+func YouTubeTestHandler(c *gin.Context) {
+	apiKey := os.Getenv("YOUTUBE_API_KEY")
+	svc := service.NewYouTubeService(apiKey)
+	title, err := svc.GetFirstVideoTitle("PLBCF2DAC6FFB574DE")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "title": title})
+}

--- a/backend/internal/service/youtube.go
+++ b/backend/internal/service/youtube.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// YouTubeService provides methods to interact with YouTube Data API.
+type YouTubeService struct {
+	APIKey string
+}
+
+// NewYouTubeService creates a new YouTubeService.
+func NewYouTubeService(key string) *YouTubeService {
+	return &YouTubeService{APIKey: key}
+}
+
+// playlistItemsResponse represents a subset of the YouTube API response.
+type playlistItemsResponse struct {
+	Items []struct {
+		Snippet struct {
+			Title string `json:"title"`
+		} `json:"snippet"`
+	} `json:"items"`
+}
+
+// GetFirstVideoTitle returns the first video's title from the given playlist.
+func (s *YouTubeService) GetFirstVideoTitle(playlistID string) (string, error) {
+	url := fmt.Sprintf("https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=1&playlistId=%s&key=%s", playlistID, s.APIKey)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("youtube api status: %s", resp.Status)
+	}
+	var data playlistItemsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", err
+	}
+	if len(data.Items) == 0 {
+		return "", fmt.Errorf("no items found")
+	}
+	return data.Items[0].Snippet.Title, nil
+}


### PR DESCRIPTION
## Summary
- ignore backend `.env`
- provide `.env.example` template with API key
- load `.env` using godotenv
- implement YouTube service and handler
- expose `/api/youtube/test` endpoint

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6850f3f8f12c8321b2a65b43ff9a9ff7