### PR TITLE
Add docs to backend image build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,6 +10,7 @@ COPY cmd/intro-quiz ./cmd/intro-quiz
 COPY internal ./internal
 COPY pkg ./pkg
 COPY config ./config
+COPY docs ./docs
 RUN go build -o server ./cmd/intro-quiz
 
 # Run stage


### PR DESCRIPTION
## Summary
- include `backend/docs` when building the backend Docker image

## Testing
- `docker compose up --build` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f7f00448832184c752dfb16c0b77