### PR TITLE
Add swagger comments for all APIs

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -37,6 +37,55 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/youtube/test": {
+            "get": {
+                "description": "Retrieve the first video's title from a fixed YouTube playlist.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "youtube"
+                ],
+                "summary": "Get first video title",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ws": {
+            "get": {
+                "description": "Upgrade the request and start echoing messages over WebSocket.",
+                "tags": [
+                    "websocket"
+                ],
+                "summary": "WebSocket endpoint",
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     }
 }`

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -30,6 +30,55 @@
                     }
                 }
             }
+        },
+        "/api/youtube/test": {
+            "get": {
+                "description": "Retrieve the first video's title from a fixed YouTube playlist.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "youtube"
+                ],
+                "summary": "Get first video title",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ws": {
+            "get": {
+                "description": "Upgrade the request and start echoing messages over WebSocket.",
+                "tags": [
+                    "websocket"
+                ],
+                "summary": "WebSocket endpoint",
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -20,4 +20,36 @@ paths:
       summary: Say hello
       tags:
       - example
+  /api/youtube/test:
+    get:
+      description: Retrieve the first video's title from a fixed YouTube playlist.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get first video title
+      tags:
+      - youtube
+  /ws:
+    get:
+      description: Upgrade the request and start echoing messages over WebSocket.
+      responses:
+        "101":
+          description: Switching Protocols
+          schema:
+            type: string
+      summary: WebSocket endpoint
+      tags:
+      - websocket
 swagger: "2.0"

--- a/backend/internal/handler/ws.go
+++ b/backend/internal/handler/ws.go
@@ -15,7 +15,12 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
-// WSHandler upgrades the connection and starts the WebSocket client.
+// WSHandler upgrades the HTTP request to a WebSocket connection.
+// @Summary      WebSocket endpoint
+// @Description  Upgrade the request and start echoing messages over WebSocket.
+// @Tags         websocket
+// @Success      101 {string} string "Switching Protocols"
+// @Router       /ws [get]
 func WSHandler(c *gin.Context) {
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {

--- a/backend/internal/handler/youtube.go
+++ b/backend/internal/handler/youtube.go
@@ -9,6 +9,13 @@ import (
 )
 
 // YouTubeTestHandler returns the first video title of a fixed playlist.
+// @Summary      Get first video title
+// @Description  Retrieve the first video's title from a fixed YouTube playlist.
+// @Tags         youtube
+// @Produce      json
+// @Success      200 {object} map[string]string
+// @Failure      500 {object} map[string]string
+// @Router       /api/youtube/test [get]
 func YouTubeTestHandler(c *gin.Context) {
 	apiKey := os.Getenv("YOUTUBE_API_KEY")
 	svc := service.NewYouTubeService(apiKey)


### PR DESCRIPTION
## Summary
- document WebSocket endpoint
- document YouTube test endpoint
- regenerate Swagger docs

## Testing
- `go vet ./...`
- `swag init -g cmd/intro-quiz/main.go`


------
https://chatgpt.com/codex/tasks/task_e_6850f992c71c8321baf2b6f851f368ee