### PR TITLE
Update README for env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ go run ./cmd/intro-quiz
 
 サーバーは `http://localhost:8080` で待ち受けます。
 
+バックエンドを起動する前に `backend/.env.example` を `backend/.env` にコピーし、
+`YOUTUBE_API_KEY` などの値を適切に設定してください。`docker-compose.yml` も
+このファイルを利用します。
+
 ### Docker での実行
 
 それぞれのディレクトリで以下を実行してイメージをビルドし、コンテナを起動できます。


### PR DESCRIPTION
## Summary
- document copying `backend/.env.example` to `.env` before running the backend
- mention that `docker-compose.yml` uses this file

## Testing
- `npm test` *(fails: Missing script: "test")*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6851498e35a08321a1a2b4caf83f6d11