### PR TITLE
Add room-based WebSocket rooms

### DIFF
--- a/backend/internal/handler/ws.go
+++ b/backend/internal/handler/ws.go
@@ -15,6 +15,8 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
+var roomManager = service.NewRoomManager()
+
 // WSHandler upgrades the HTTP request to a WebSocket connection.
 // @Summary      WebSocket endpoint
 // @Description  Upgrade the request and start echoing messages over WebSocket.
@@ -22,14 +24,21 @@ var upgrader = websocket.Upgrader{
 // @Success      101 {string} string "Switching Protocols"
 // @Router       /ws [get]
 func WSHandler(c *gin.Context) {
+	roomID := c.Query("roomId")
+	if roomID == "" {
+		roomID = "default"
+	}
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		log.Printf("upgrade: %v", err)
 		return
 	}
-	svc := service.NewEchoService()
+	roomManager.Join(roomID, conn)
+	defer roomManager.Leave(roomID, conn)
+
+	svc := service.NewRoomService(roomManager, roomID, conn)
 	client := ws.NewClient(conn, svc)
-	log.Printf("client connected: %s", conn.RemoteAddr())
+	log.Printf("client connected: %s room:%s", conn.RemoteAddr(), roomID)
 	client.Listen()
-	log.Printf("client disconnected: %s", conn.RemoteAddr())
+	log.Printf("client disconnected: %s room:%s", conn.RemoteAddr(), roomID)
 }

--- a/backend/internal/service/room.go
+++ b/backend/internal/service/room.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+// RoomManager manages WebSocket connections grouped by room ID.
+type RoomManager struct {
+	rooms map[string]map[*websocket.Conn]bool
+	mu    sync.RWMutex
+}
+
+// NewRoomManager creates a new RoomManager.
+func NewRoomManager() *RoomManager {
+	return &RoomManager{rooms: make(map[string]map[*websocket.Conn]bool)}
+}
+
+// Join adds a connection to a room.
+func (m *RoomManager) Join(roomID string, conn *websocket.Conn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.rooms[roomID]; !ok {
+		m.rooms[roomID] = make(map[*websocket.Conn]bool)
+	}
+	m.rooms[roomID][conn] = true
+}
+
+// Leave removes a connection from a room.
+func (m *RoomManager) Leave(roomID string, conn *websocket.Conn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if clients, ok := m.rooms[roomID]; ok {
+		delete(clients, conn)
+		if len(clients) == 0 {
+			delete(m.rooms, roomID)
+		}
+	}
+}
+
+// Broadcast sends a message to all clients in the room except the sender.
+func (m *RoomManager) Broadcast(roomID string, sender *websocket.Conn, mt int, msg []byte) {
+	m.mu.RLock()
+	clients := m.rooms[roomID]
+	m.mu.RUnlock()
+
+	for conn := range clients {
+		if conn == sender {
+			continue
+		}
+		conn.WriteMessage(mt, msg) // ignore errors for simplicity
+	}
+}
+
+// RoomService uses RoomManager to broadcast messages within a room.
+type RoomService struct {
+	manager *RoomManager
+	roomID  string
+	conn    *websocket.Conn
+}
+
+// NewRoomService creates a RoomService for a specific connection and room.
+func NewRoomService(m *RoomManager, roomID string, conn *websocket.Conn) *RoomService {
+	return &RoomService{manager: m, roomID: roomID, conn: conn}
+}
+
+// ProcessMessage broadcasts the received message to the room.
+func (r *RoomService) ProcessMessage(mt int, msg []byte) (int, []byte) {
+	r.manager.Broadcast(r.roomID, r.conn, mt, msg)
+	return 0, nil
+}

--- a/backend/pkg/ws/client.go
+++ b/backend/pkg/ws/client.go
@@ -33,9 +33,11 @@ func (c *Client) Listen() {
 		}
 		log.Printf("recv: %s", msg)
 		respType, respMsg := c.Service.ProcessMessage(mt, msg)
-		if err := c.Conn.WriteMessage(respType, respMsg); err != nil {
-			log.Printf("write: %v", err)
-			break
+		if respMsg != nil {
+			if err := c.Conn.WriteMessage(respType, respMsg); err != nil {
+				log.Printf("write: %v", err)
+				break
+			}
 		}
 	}
 }

--- a/frontend/src/features/room/RoomJoinForm.jsx
+++ b/frontend/src/features/room/RoomJoinForm.jsx
@@ -1,21 +1,21 @@
-import { useState } from 'react'
+import { useState } from "react";
 
 export default function RoomJoinForm({ onJoin }) {
-  const [name, setName] = useState('')
+  const [roomId, setRoomId] = useState("");
 
   const submit = (e) => {
-    e.preventDefault()
-    onJoin(name)
-  }
+    e.preventDefault();
+    onJoin(roomId);
+  };
 
   return (
     <form onSubmit={submit}>
       <input
-        placeholder="Enter name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
+        placeholder="ルームIDを入力してください"
+        value={roomId}
+        onChange={(e) => setRoomId(e.target.value)}
       />
-      <button type="submit">Join</button>
+      <button type="submit">参加</button>
     </form>
-  )
+  );
 }

--- a/frontend/src/hooks/useWebSocket.js
+++ b/frontend/src/hooks/useWebSocket.js
@@ -1,25 +1,25 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef } from "react";
 
 export default function useWebSocket(url) {
-  const socketRef = useRef(null)
+  const socketRef = useRef(null);
 
-  const connect = (onMessage) => {
-    const socket = new WebSocket(url)
-    socketRef.current = socket
-    socket.onmessage = onMessage
-  }
+  const connect = (roomId, onMessage) => {
+    const socket = new WebSocket(`${url}?roomId=${roomId}`);
+    socketRef.current = socket;
+    socket.onmessage = onMessage;
+  };
 
   useEffect(() => {
     return () => {
-      socketRef.current?.close()
-    }
-  }, [])
+      socketRef.current?.close();
+    };
+  }, []);
 
   const send = (data) => {
     if (socketRef.current?.readyState === WebSocket.OPEN) {
-      socketRef.current.send(data)
+      socketRef.current.send(data);
     }
-  }
+  };
 
-  return { connect, send }
+  return { connect, send };
 }

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -1,23 +1,25 @@
-import { useState } from 'react'
-import RoomJoinForm from '../features/room/RoomJoinForm'
-import { useRoomStore } from '../stores/roomStore'
-import useWebSocket from '../hooks/useWebSocket'
-import { WS_URL } from '../services/websocket'
+import { useState } from "react";
+import RoomJoinForm from "../features/room/RoomJoinForm";
+import { useRoomStore } from "../stores/roomStore";
+import useWebSocket from "../hooks/useWebSocket";
+import { WS_URL } from "../services/websocket";
 
 export default function RoomPage() {
-  const addMessage = useRoomStore((state) => state.addMessage)
-  const messages = useRoomStore((state) => state.messages)
-  const [joined, setJoined] = useState(false)
-  const { connect, send } = useWebSocket(WS_URL)
+  const addMessage = useRoomStore((state) => state.addMessage);
+  const clearMessages = useRoomStore((state) => state.clearMessages);
+  const messages = useRoomStore((state) => state.messages);
+  const [joined, setJoined] = useState(false);
+  const { connect, send } = useWebSocket(WS_URL);
 
-  const handleJoin = () => {
-    connect((event) => addMessage(event.data))
-    setJoined(true)
-  }
+  const handleJoin = (roomId) => {
+    clearMessages();
+    connect(roomId, (event) => addMessage(event.data));
+    setJoined(true);
+  };
 
   const sendTest = () => {
-    send('test')
-  }
+    send("test");
+  };
 
   return (
     <div>
@@ -34,5 +36,5 @@ export default function RoomPage() {
         <RoomJoinForm onJoin={handleJoin} />
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/stores/roomStore.js
+++ b/frontend/src/stores/roomStore.js
@@ -1,6 +1,7 @@
-import { create } from 'zustand'
+import { create } from "zustand";
 
 export const useRoomStore = create((set) => ({
   messages: [],
   addMessage: (msg) => set((state) => ({ messages: [...state.messages, msg] })),
-}))
+  clearMessages: () => set({ messages: [] }),
+}));


### PR DESCRIPTION
## Summary
- implement `RoomManager` and `RoomService` on backend
- join/leave rooms and broadcast to same-room clients only
- update WebSocket client to handle optional response
- add room ID join form and JS state cleanup
- connect using `?roomId=` query param

## Testing
- `go build ./cmd/intro-quiz`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68514d02180c8321858f01b193ce4e7d