### PR TITLE
Add readiness tracking with Ready button

### DIFF
--- a/backend/internal/model/wsmessage.go
+++ b/backend/internal/model/wsmessage.go
@@ -8,7 +8,8 @@ type ClientMessage struct {
 
 // ServerMessage represents a message sent to clients.
 type ServerMessage struct {
-	Type      string `json:"type"`
-	User      string `json:"user,omitempty"`
-	Timestamp int64  `json:"timestamp"`
+	Type       string          `json:"type"`
+	User       string          `json:"user,omitempty"`
+	Timestamp  int64           `json:"timestamp"`
+	ReadyUsers map[string]bool `json:"readyUsers,omitempty"`
 }

--- a/frontend/src/hooks/useWebSocket.js
+++ b/frontend/src/hooks/useWebSocket.js
@@ -3,10 +3,11 @@ import { useEffect, useRef } from "react";
 export default function useWebSocket(url) {
   const socketRef = useRef(null);
 
-  const connect = (roomId, onMessage) => {
+  const connect = (roomId, onMessage, onOpen) => {
     const socket = new WebSocket(`${url}?roomId=${roomId}`);
     socketRef.current = socket;
     socket.onmessage = onMessage;
+    if (onOpen) socket.onopen = onOpen;
   };
 
   useEffect(() => {

--- a/frontend/src/stores/roomStore.js
+++ b/frontend/src/stores/roomStore.js
@@ -8,4 +8,6 @@ export const useRoomStore = create((set) => ({
   winner: null,
   setQuestionActive: (active) => set({ questionActive: active }),
   setWinner: (name) => set({ winner: name }),
+  readyStates: {},
+  setReadyStates: (states) => set({ readyStates: states }),
 }));


### PR DESCRIPTION
## Summary
- track ready state per participant on the server
- broadcast ready state updates
- add Ready button to RoomPage
- show each user's readiness
- send user name on join via WebSocket

## Testing
- `go build ./...`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851549d774483219a17a00881d22999