### PR TITLE
Add random YouTube video selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ go run ./cmd/intro-quiz
 サーバーは `http://localhost:8080` で待ち受けます。
 
 バックエンドを起動する前に `backend/.env.example` を `backend/.env` にコピーし、
-`YOUTUBE_API_KEY` などの値を適切に設定してください。`docker-compose.yml` も
-このファイルを利用します。
+`YOUTUBE_API_KEY` や `YOUTUBE_PLAYLIST_ID` などの値を適切に設定してください。
+`docker-compose.yml` もこのファイルを利用します。
 
 ### Docker での実行
 
@@ -77,4 +77,3 @@ docker run -p 8080:8080 intro-quiz-backend
 ```bash
 docker-compose up --build
 ```
-

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables for the Intro-Quiz backend
 YOUTUBE_API_KEY=your_api_key_here
+YOUTUBE_PLAYLIST_ID=your_playlist_id_here
 PORT=8080

--- a/backend/internal/handler/ws.go
+++ b/backend/internal/handler/ws.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"log"
 	"net/http"
+	"os"
 
 	"intro-quiz/backend/internal/service"
 	"intro-quiz/backend/pkg/ws"
@@ -16,6 +17,8 @@ var upgrader = websocket.Upgrader{
 }
 
 var roomManager = service.NewRoomManager()
+var youtubeService = service.NewYouTubeService(os.Getenv("YOUTUBE_API_KEY"))
+var playlistID = os.Getenv("YOUTUBE_PLAYLIST_ID")
 
 // WSHandler upgrades the HTTP request to a WebSocket connection.
 // @Summary      WebSocket endpoint
@@ -36,7 +39,7 @@ func WSHandler(c *gin.Context) {
 	roomManager.Join(roomID, conn)
 	defer roomManager.Leave(roomID, conn)
 
-	svc := service.NewRoomService(roomManager, roomID, conn)
+	svc := service.NewRoomService(roomManager, roomID, conn, youtubeService, playlistID)
 	client := ws.NewClient(conn, svc)
 	log.Printf("client connected: %s room:%s", conn.RemoteAddr(), roomID)
 	client.Listen()

--- a/backend/internal/model/wsmessage.go
+++ b/backend/internal/model/wsmessage.go
@@ -11,5 +11,6 @@ type ServerMessage struct {
 	Type       string          `json:"type"`
 	User       string          `json:"user,omitempty"`
 	Timestamp  int64           `json:"timestamp"`
+	VideoID    string          `json:"videoId,omitempty"`
 	ReadyUsers map[string]bool `json:"readyUsers,omitempty"`
 }

--- a/backend/internal/service/room.go
+++ b/backend/internal/service/room.go
@@ -16,6 +16,7 @@ type RoomState struct {
 	Active  bool
 	Ready   map[string]bool
 	Users   map[*websocket.Conn]string
+	VideoID string
 }
 
 // RoomManager manages WebSocket connections grouped by room ID and quiz state.
@@ -124,7 +125,7 @@ func (m *RoomManager) Broadcast(roomID string, sender *websocket.Conn, mt int, m
 }
 
 // StartQuestion marks the room as active and resets fastest user.
-func (m *RoomManager) StartQuestion(roomID string) {
+func (m *RoomManager) StartQuestion(roomID, videoID string) {
 	m.mu.Lock()
 	st, ok := m.states[roomID]
 	if !ok {
@@ -133,6 +134,7 @@ func (m *RoomManager) StartQuestion(roomID string) {
 	}
 	st.Active = true
 	st.Fastest = ""
+	st.VideoID = videoID
 	m.mu.Unlock()
 
 	go func() {
@@ -176,14 +178,16 @@ func (m *RoomManager) IsActive(roomID string) bool {
 
 // RoomService uses RoomManager to broadcast messages within a room.
 type RoomService struct {
-	manager *RoomManager
-	roomID  string
-	conn    *websocket.Conn
+	manager    *RoomManager
+	roomID     string
+	conn       *websocket.Conn
+	yt         *YouTubeService
+	playlistID string
 }
 
 // NewRoomService creates a RoomService for a specific connection and room.
-func NewRoomService(m *RoomManager, roomID string, conn *websocket.Conn) *RoomService {
-	return &RoomService{manager: m, roomID: roomID, conn: conn}
+func NewRoomService(m *RoomManager, roomID string, conn *websocket.Conn, yt *YouTubeService, playlistID string) *RoomService {
+	return &RoomService{manager: m, roomID: roomID, conn: conn, yt: yt, playlistID: playlistID}
 }
 
 // ProcessMessage broadcasts the received message to the room.
@@ -205,13 +209,21 @@ func (r *RoomService) ProcessMessage(mt int, msg []byte) (int, []byte) {
 		r.conn.WriteMessage(websocket.TextMessage, resp)
 		r.manager.Broadcast(r.roomID, r.conn, websocket.TextMessage, resp)
 		if all {
-			r.manager.StartQuestion(r.roomID)
-			startMsg, _ := json.Marshal(&model.ServerMessage{Type: "start", Timestamp: time.Now().UnixMilli()})
+			videoID, err := r.yt.GetRandomVideoID(r.playlistID)
+			if err != nil {
+				return 0, nil
+			}
+			r.manager.StartQuestion(r.roomID, videoID)
+			startMsg, _ := json.Marshal(&model.ServerMessage{Type: "start", VideoID: videoID, Timestamp: time.Now().UnixMilli()})
 			r.manager.Broadcast(r.roomID, nil, websocket.TextMessage, startMsg)
 		}
 	case "start":
-		r.manager.StartQuestion(r.roomID)
-		resp, _ := json.Marshal(&model.ServerMessage{Type: "start", Timestamp: time.Now().UnixMilli()})
+		videoID, err := r.yt.GetRandomVideoID(r.playlistID)
+		if err != nil {
+			return 0, nil
+		}
+		r.manager.StartQuestion(r.roomID, videoID)
+		resp, _ := json.Marshal(&model.ServerMessage{Type: "start", VideoID: videoID, Timestamp: time.Now().UnixMilli()})
 		r.manager.Broadcast(r.roomID, nil, websocket.TextMessage, resp)
 	case "buzz":
 		// broadcast that someone pressed the answer button

--- a/backend/internal/service/youtube.go
+++ b/backend/internal/service/youtube.go
@@ -3,7 +3,9 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
+	"time"
 )
 
 // YouTubeService provides methods to interact with YouTube Data API.
@@ -20,7 +22,10 @@ func NewYouTubeService(key string) *YouTubeService {
 type playlistItemsResponse struct {
 	Items []struct {
 		Snippet struct {
-			Title string `json:"title"`
+			Title      string `json:"title"`
+			ResourceID struct {
+				VideoID string `json:"videoId"`
+			} `json:"resourceId"`
 		} `json:"snippet"`
 	} `json:"items"`
 }
@@ -44,4 +49,27 @@ func (s *YouTubeService) GetFirstVideoTitle(playlistID string) (string, error) {
 		return "", fmt.Errorf("no items found")
 	}
 	return data.Items[0].Snippet.Title, nil
+}
+
+// GetRandomVideoID returns a random video ID from the given playlist.
+func (s *YouTubeService) GetRandomVideoID(playlistID string) (string, error) {
+	url := fmt.Sprintf("https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId=%s&key=%s", playlistID, s.APIKey)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("youtube api status: %s", resp.Status)
+	}
+	var data playlistItemsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", err
+	}
+	if len(data.Items) == 0 {
+		return "", fmt.Errorf("no items found")
+	}
+	rand.Seed(time.Now().UnixNano())
+	pick := rand.Intn(len(data.Items))
+	return data.Items[pick].Snippet.ResourceID.VideoID, nil
 }

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -15,6 +15,8 @@ export default function RoomPage() {
   const messages = useRoomStore((state) => state.messages);
   const readyStates = useRoomStore((state) => state.readyStates);
   const setReadyStates = useRoomStore((state) => state.setReadyStates);
+  const setCurrentVideoId = useRoomStore((state) => state.setCurrentVideoId);
+  const currentVideoId = useRoomStore((state) => state.currentVideoId);
   const [joined, setJoined] = useState(false);
   const [name, setName] = useState("");
   const [roomId, setRoomId] = useState("");
@@ -36,6 +38,7 @@ export default function RoomPage() {
           setQuestionActive(true);
           setWinner(null);
           setPauseInfo("");
+          setCurrentVideoId(data.videoId);
           setPlaying(true);
           setTimeLeft(10);
           if (timerRef.current) clearInterval(timerRef.current);
@@ -96,9 +99,9 @@ export default function RoomPage() {
               {u}さん：{r ? "準備完了" : "未準備"}
             </p>
           ))}
-          {playing && <p>再生中…</p>}
+          {playing && <p>問題を再生中…</p>}
           {pauseInfo && <p>{pauseInfo}</p>}
-          <YouTubePlayer videoId="M7lc1UVf-VE" playing={playing} />
+          <YouTubePlayer videoId={currentVideoId} playing={playing} />
           {questionActive && (
             <div>
               <p>制限時間: {timeLeft}秒</p>

--- a/frontend/src/stores/roomStore.js
+++ b/frontend/src/stores/roomStore.js
@@ -10,4 +10,6 @@ export const useRoomStore = create((set) => ({
   setWinner: (name) => set({ winner: name }),
   readyStates: {},
   setReadyStates: (states) => set({ readyStates: states }),
+  currentVideoId: null,
+  setCurrentVideoId: (id) => set({ currentVideoId: id }),
 }));


### PR DESCRIPTION
## Summary
- add YouTube playlist ID env var
- fetch random video from playlist and broadcast per round
- store selected video in room state and send to clients
- show playback message and play selected video on frontend

## Testing
- `go vet ./...`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68516b654e04832180d710f2c7a39fbe