### PR TITLE
Improve WebSocket error logging

### DIFF
--- a/backend/internal/handler/ws.go
+++ b/backend/internal/handler/ws.go
@@ -36,7 +36,7 @@ func WSHandler(c *gin.Context) {
 		log.Printf("upgrade: %v", err)
 		return
 	}
-	client := ws.NewClient(conn, nil)
+	client := ws.NewClient(conn, roomID, nil)
 	svc := service.NewRoomService(roomManager, roomID, client, youtubeService, playlistID)
 	client.Service = svc
 	roomManager.Join(roomID, client)

--- a/backend/pkg/ws/client.go
+++ b/backend/pkg/ws/client.go
@@ -17,6 +17,7 @@ type Client struct {
 	Conn    *websocket.Conn
 	Service MessageService
 	Send    chan OutgoingMessage
+	RoomID  string
 }
 
 // MessageService defines processing behavior for incoming messages.
@@ -24,16 +25,19 @@ type MessageService interface {
 	ProcessMessage(messageType int, message []byte) (int, []byte)
 }
 
-// NewClient creates a Client bound to the given service.
-func NewClient(conn *websocket.Conn, svc MessageService) *Client {
+// NewClient creates a Client bound to the given service and room.
+func NewClient(conn *websocket.Conn, roomID string, svc MessageService) *Client {
 	return &Client{
 		Conn:    conn,
 		Service: svc,
 		Send:    make(chan OutgoingMessage, 8),
+		RoomID:  roomID,
 	}
 }
 
 // Listen reads messages from the WebSocket and sends back the processed result.
+// When ReadMessage or WriteMessage returns an error, the error is logged along
+// with the room ID and remote address. The connection then closes.
 func (c *Client) Listen() {
 	defer c.Conn.Close()
 
@@ -42,7 +46,7 @@ func (c *Client) Listen() {
 	go func() {
 		for msg := range c.Send {
 			if err := c.Conn.WriteMessage(msg.Type, msg.Data); err != nil {
-				log.Printf("write: %v", err)
+				log.Printf("write error room:%s addr:%s err:%v", c.RoomID, c.Conn.RemoteAddr(), err)
 				break
 			}
 		}
@@ -52,7 +56,7 @@ func (c *Client) Listen() {
 	for {
 		mt, msg, err := c.Conn.ReadMessage()
 		if err != nil {
-			log.Printf("read: %v", err)
+			log.Printf("read error room:%s addr:%s err:%v", c.RoomID, c.Conn.RemoteAddr(), err)
 			break
 		}
 		log.Printf("recv: %s", msg)


### PR DESCRIPTION
## Summary
- include roomID in new `Client` field
- create `NewClient` with room ID argument
- log WebSocket read/write errors with room and remote address
- document connection closure after logging

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6851714c5b6c832192b45bdce4e71397