### PR TITLE
Add WebSocket client component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 *.out
 .DS_Store
 backend/.env
+frontend/dist

--- a/frontend/src/components/WebSocketClient.jsx
+++ b/frontend/src/components/WebSocketClient.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from "react";
+import { WS_URL } from "../services/websocket";
+
+export default function WebSocketClient({ roomId, user }) {
+  const wsRef = useRef(null);
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    if (!roomId || !user) return;
+    const ws = new WebSocket(`${WS_URL}?roomId=${roomId}`);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: "join", user }));
+    };
+
+    ws.onmessage = (event) => {
+      setMessages((prev) => [...prev, event.data]);
+    };
+
+    return () => {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close(1000, "normal closure");
+      }
+    };
+  }, [roomId, user]);
+
+  const sendReady = () => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: "ready", user }));
+    }
+  };
+
+  return (
+    <div>
+      <button onClick={sendReady}>Send Ready</button>
+      <ul>
+        {messages.map((msg, i) => (
+          <li key={i}>{msg}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `WebSocketClient` component for handling the WebSocket lifecycle
- ignore frontend build output

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851773814348321b3919befb78c9b27