### PR TITLE
Add minimal YouTube player example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,43 @@ docker run -p 8080:8080 intro-quiz-backend
 ```bash
 docker-compose up --build
 ```
+
+## 最小構成の YouTube プレイヤー例
+
+react-youtube を利用する際は、iframe の読み込み完了前に再生を試みるとエラーが発生します。
+onReady イベントで読み込みを確認してから再生コマンドを送る例を以下に示します。
+
+```jsx
+import { useEffect, useRef, useState } from "react";
+import YouTube from "react-youtube";
+
+export default function MinimalYouTubePlayer({ videoId, playing }) {
+  const playerRef = useRef(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const opts = {
+    playerVars: {
+      origin: window.location.origin,
+      enablejsapi: 1,
+    },
+  };
+
+  const handleReady = (event) => {
+    playerRef.current = event.target;
+    setIsReady(true);
+  };
+
+  useEffect(() => {
+    if (!isReady) return;
+    if (playing) {
+      playerRef.current.playVideo();
+    } else {
+      playerRef.current.pauseVideo();
+    }
+  }, [playing, isReady]);
+
+  return <YouTube videoId={videoId} opts={opts} onReady={handleReady} />;
+}
+```
+
+このコンポーネントを使うことで、`playing` が `true` のときに iframe が準備でき次第、自動で動画が再生されます。

--- a/frontend/src/components/MinimalYouTubePlayer.jsx
+++ b/frontend/src/components/MinimalYouTubePlayer.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from "react";
+import YouTube from "react-youtube";
+
+// Minimal player component that waits for the iframe to be ready
+// before sending play or pause commands.
+export default function MinimalYouTubePlayer({ videoId, playing }) {
+  const playerRef = useRef(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const opts = {
+    playerVars: {
+      // Setting origin and enablejsapi is required for postMessage to work
+      origin: window.location.origin,
+      enablejsapi: 1,
+    },
+  };
+
+  const handleReady = (event) => {
+    // Store the player instance and mark as ready
+    playerRef.current = event.target;
+    setIsReady(true);
+  };
+
+  useEffect(() => {
+    if (!isReady) return;
+
+    if (playing) {
+      playerRef.current.playVideo();
+    } else {
+      playerRef.current.pauseVideo();
+    }
+  }, [playing, isReady]);
+
+  return (
+    <YouTube videoId={videoId} opts={opts} onReady={handleReady} />
+  );
+}


### PR DESCRIPTION
## Summary
- add `MinimalYouTubePlayer` demonstrating how to wait for onReady before controlling playback
- document minimal usage in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68517b00534c832197f17fdc2e94d8e0