### PR TITLE
Add random YouTube video endpoint

### DIFF
--- a/backend/cmd/intro-quiz/main.go
+++ b/backend/cmd/intro-quiz/main.go
@@ -24,6 +24,7 @@ func main() {
 
 	router.GET("/ws", handler.WSHandler)
 	router.GET("/api/youtube/test", handler.YouTubeTestHandler)
+	router.GET("/api/youtube/random", handler.YouTubeRandomHandler)
 	router.GET("/api/hello", handler.HelloHandler)
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -38,6 +38,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/youtube/random": {
+            "get": {
+                "description": "Retrieve a random video's ID from a YouTube playlist.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "youtube"
+                ],
+                "summary": "Get random video ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Playlist ID",
+                        "name": "playlistId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/youtube/test": {
             "get": {
                 "description": "Retrieve the first video's title from a fixed YouTube playlist.",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -31,6 +31,56 @@
                 }
             }
         },
+        "/api/youtube/random": {
+            "get": {
+                "description": "Retrieve a random video's ID from a YouTube playlist.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "youtube"
+                ],
+                "summary": "Get random video ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Playlist ID",
+                        "name": "playlistId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/youtube/test": {
             "get": {
                 "description": "Retrieve the first video's title from a fixed YouTube playlist.",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -20,6 +20,39 @@ paths:
       summary: Say hello
       tags:
       - example
+  /api/youtube/random:
+    get:
+      description: Retrieve a random video's ID from a YouTube playlist.
+      parameters:
+      - description: Playlist ID
+        in: query
+        name: playlistId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get random video ID
+      tags:
+      - youtube
   /api/youtube/test:
     get:
       description: Retrieve the first video's title from a fixed YouTube playlist.

--- a/backend/internal/handler/youtube.go
+++ b/backend/internal/handler/youtube.go
@@ -26,3 +26,29 @@ func YouTubeTestHandler(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "title": title})
 }
+
+// YouTubeRandomHandler returns a random video ID from the specified playlist.
+// @Summary      Get random video ID
+// @Description  Retrieve a random video's ID from a YouTube playlist.
+// @Tags         youtube
+// @Produce      json
+// @Param        playlistId  query     string  true  "Playlist ID"
+// @Success      200 {object} map[string]string
+// @Failure      400 {object} map[string]string
+// @Failure      500 {object} map[string]string
+// @Router       /api/youtube/random [get]
+func YouTubeRandomHandler(c *gin.Context) {
+	playlistID := c.Query("playlistId")
+	if playlistID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "playlistId required"})
+		return
+	}
+	apiKey := os.Getenv("YOUTUBE_API_KEY")
+	svc := service.NewYouTubeService(apiKey)
+	videoID, err := svc.GetRandomVideoID(playlistID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "videoId": videoID})
+}

--- a/backend/internal/service/youtube.go
+++ b/backend/internal/service/youtube.go
@@ -3,7 +3,9 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
+	"time"
 )
 
 // YouTubeService provides methods to interact with YouTube Data API.
@@ -18,9 +20,17 @@ func NewYouTubeService(key string) *YouTubeService {
 
 // playlistItemsResponse represents a subset of the YouTube API response.
 type playlistItemsResponse struct {
+	NextPageToken string `json:"nextPageToken"`
+	PageInfo      struct {
+		TotalResults   int `json:"totalResults"`
+		ResultsPerPage int `json:"resultsPerPage"`
+	} `json:"pageInfo"`
 	Items []struct {
 		Snippet struct {
-			Title string `json:"title"`
+			Title      string `json:"title"`
+			ResourceID struct {
+				VideoID string `json:"videoId"`
+			} `json:"resourceId"`
 		} `json:"snippet"`
 	} `json:"items"`
 }
@@ -44,4 +54,65 @@ func (s *YouTubeService) GetFirstVideoTitle(playlistID string) (string, error) {
 		return "", fmt.Errorf("no items found")
 	}
 	return data.Items[0].Snippet.Title, nil
+}
+
+// GetRandomVideoID returns a random video's ID from the specified playlist.
+func (s *YouTubeService) GetRandomVideoID(playlistID string) (string, error) {
+	rand.Seed(time.Now().UnixNano())
+	maxResults := 50
+
+	// Initial request to obtain total results and first page of items
+	url := fmt.Sprintf("https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=%d&playlistId=%s&key=%s", maxResults, playlistID, s.APIKey)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("youtube api status: %s", resp.Status)
+	}
+
+	var data playlistItemsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", err
+	}
+
+	total := data.PageInfo.TotalResults
+	if total == 0 || len(data.Items) == 0 {
+		return "", fmt.Errorf("no items found")
+	}
+
+	// Select a random index across total results
+	target := rand.Intn(total)
+	page := target / maxResults
+	index := target % maxResults
+
+	// If target within first page, use already fetched data
+	items := data.Items
+	token := data.NextPageToken
+	for i := 0; i < page; i++ {
+		if token == "" {
+			return "", fmt.Errorf("page token missing")
+		}
+		pageURL := fmt.Sprintf("https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=%d&pageToken=%s&playlistId=%s&key=%s", maxResults, token, playlistID, s.APIKey)
+		resp, err := http.Get(pageURL)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("youtube api status: %s", resp.Status)
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return "", err
+		}
+		items = data.Items
+		token = data.NextPageToken
+	}
+
+	if index >= len(items) {
+		return "", fmt.Errorf("index out of range")
+	}
+
+	return items[index].Snippet.ResourceID.VideoID, nil
 }


### PR DESCRIPTION
## Summary
- add GetRandomVideoID service method using playlistItems API
- expose GET `/api/youtube/random` endpoint
- register the route in main.go
- regenerate Swagger docs

## Testing
- `go test ./...`
- `swag init -g cmd/intro-quiz/main.go -o docs`


------
https://chatgpt.com/codex/tasks/task_e_6851fe715c808321a09f62db3842fb77