### PR TITLE
Add playlist ID support and fetch random video

### DIFF
--- a/frontend/src/features/room/RoomJoinForm.jsx
+++ b/frontend/src/features/room/RoomJoinForm.jsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 export default function RoomJoinForm({ onJoin }) {
   const [roomId, setRoomId] = useState("");
   const [name, setName] = useState("");
+  const [playlistId, setPlaylistId] = useState("");
 
   const submit = (e) => {
     e.preventDefault();
-    onJoin(roomId, name);
+    onJoin(roomId, name, playlistId);
   };
 
   return (
@@ -20,6 +21,11 @@ export default function RoomJoinForm({ onJoin }) {
         placeholder="名前を入力してください"
         value={name}
         onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        placeholder="プレイリストIDを入力してください"
+        value={playlistId}
+        onChange={(e) => setPlaylistId(e.target.value)}
       />
       <button type="submit">参加</button>
     </form>

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -3,6 +3,7 @@ import RoomJoinForm from "../features/room/RoomJoinForm";
 import { useRoomStore } from "../stores/roomStore";
 import useWebSocket from "../hooks/useWebSocket";
 import { WS_URL } from "../services/websocket";
+import { API_URL } from "../services/api";
 import YouTubePlayer from "../components/YouTubePlayer";
 
 export default function RoomPage() {
@@ -18,16 +19,19 @@ export default function RoomPage() {
   const [joined, setJoined] = useState(false);
   const [name, setName] = useState("");
   const [roomId, setRoomId] = useState("");
+  const [playlistId, setPlaylistId] = useState("");
+  const [videoId, setVideoId] = useState("");
   const [timeLeft, setTimeLeft] = useState(0);
   const [playing, setPlaying] = useState(false);
   const [pauseInfo, setPauseInfo] = useState("");
   const timerRef = useRef(null);
   const { connect, send } = useWebSocket(WS_URL);
 
-  const handleJoin = (rid, userName) => {
+  const handleJoin = (rid, userName, pid) => {
     clearMessages();
     setName(userName);
     setRoomId(rid);
+    setPlaylistId(pid);
     connect(
       rid,
       (event) => {
@@ -62,6 +66,13 @@ export default function RoomPage() {
       },
       () => {
         send(JSON.stringify({ type: "join", user: userName }));
+        fetch(`${API_URL}/api/youtube/random?playlistId=${encodeURIComponent(pid)}`)
+          .then((res) => res.json())
+          .then((data) => {
+            if (data.videoId) {
+              setVideoId(data.videoId);
+            }
+          });
       },
     );
     setReadyStates({});
@@ -98,7 +109,7 @@ export default function RoomPage() {
           ))}
           {playing && <p>再生中…</p>}
           {pauseInfo && <p>{pauseInfo}</p>}
-          <YouTubePlayer videoId="M7lc1UVf-VE" playing={playing} />
+          <YouTubePlayer videoId={videoId} playing={playing} />
           {questionActive && (
             <div>
               <p>制限時間: {timeLeft}秒</p>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8080';


### PR DESCRIPTION
## Summary
- extend RoomJoinForm with playlist ID input and propagate state
- store playlist ID and video ID in RoomPage
- fetch random video after joining a room using new API service

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851ffd347108321908a570dbcf6248c