### PR TITLE
Fix timer cleanup in RoomPage

### DIFF
--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -51,11 +51,13 @@ export default function RoomPage() {
           setQuestionActive(false);
           setPlaying(false);
           clearInterval(timerRef.current);
+          timerRef.current = null;
         } else if (data.type === "timeout") {
           setWinner(null);
           setQuestionActive(false);
           setPlaying(false);
           clearInterval(timerRef.current);
+          timerRef.current = null;
         } else if (data.type === "answer") {
           setPlaying(false);
           setPauseInfo(`${data.user}さんが解答ボタンを押しました - 再生停止中`);
@@ -92,7 +94,14 @@ export default function RoomPage() {
   useEffect(() => {
     if (!questionActive && timerRef.current) {
       clearInterval(timerRef.current);
+      timerRef.current = null;
     }
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
   }, [questionActive]);
 
   return (


### PR DESCRIPTION
## Summary
- clear `timerRef.current` after timeout or buzz result
- return cleanup function in `useEffect`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68529d281c7c8321ab2609a6a5a7c037