### PR TITLE
Extend question timer to 30 seconds

### DIFF
--- a/backend/internal/service/room.go
+++ b/backend/internal/service/room.go
@@ -136,7 +136,8 @@ func (m *RoomManager) StartQuestion(roomID string) {
 	m.mu.Unlock()
 
 	go func() {
-		time.Sleep(10 * time.Second)
+               // Allow 30 seconds for players to buzz in
+               time.Sleep(30 * time.Second)
 		m.mu.Lock()
 		st := m.states[roomID]
 		if st != nil && st.Active && st.Fastest == "" {

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -41,7 +41,8 @@ export default function RoomPage() {
           setWinner(null);
           setPauseInfo("");
           setPlaying(true);
-          setTimeLeft(10);
+          // Set countdown timer to 30 seconds
+          setTimeLeft(30);
           if (timerRef.current) clearInterval(timerRef.current);
           timerRef.current = setInterval(() => {
             setTimeLeft((t) => (t > 0 ? t - 1 : 0));


### PR DESCRIPTION
## Summary
- increase answer time limit from 10 seconds to 30 seconds in backend service
- adjust frontend countdown timer accordingly

## Testing
- `go test ./...`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852a06f514883218fb5a5beb64b53b6