### PR TITLE
Enable CORS for local frontend

### DIFF
--- a/backend/cmd/intro-quiz/main.go
+++ b/backend/cmd/intro-quiz/main.go
@@ -1,24 +1,45 @@
 package main
 
 import (
-	"log"
+        "log"
+        "net/http"
 
-	"github.com/gin-gonic/gin"
-	swaggerFiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
+        "github.com/gin-gonic/gin"
+        swaggerFiles "github.com/swaggo/files"
+        ginSwagger "github.com/swaggo/gin-swagger"
 
 	"intro-quiz/backend/docs"
-	"intro-quiz/backend/internal/config"
-	"intro-quiz/backend/internal/handler"
+        "intro-quiz/backend/internal/config"
+        "intro-quiz/backend/internal/handler"
 )
+
+// CORSMiddleware sets CORS headers to allow requests from the frontend.
+func CORSMiddleware() gin.HandlerFunc {
+        return func(c *gin.Context) {
+                origin := c.GetHeader("Origin")
+                if origin == "http://localhost" || origin == "http://localhost:3000" || origin == "http://localhost:5173" {
+                        c.Header("Access-Control-Allow-Origin", origin)
+                }
+                c.Header("Access-Control-Allow-Credentials", "true")
+                c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+                c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+
+                if c.Request.Method == http.MethodOptions {
+                        c.AbortWithStatus(204)
+                        return
+                }
+                c.Next()
+        }
+}
 
 // @title Intro Quiz API
 // @version 1.0
 // @description This is the REST API for the Intro Quiz backend.
 // @BasePath /
 func main() {
-	config.LoadEnv()
-	router := gin.Default()
+        config.LoadEnv()
+        router := gin.Default()
+        router.Use(CORSMiddleware())
 
 	docs.SwaggerInfo.BasePath = "/"
 


### PR DESCRIPTION
## Summary
- allow requests from localhost by setting custom CORS middleware

## Testing
- `go vet ./...`
- `go build ./cmd/intro-quiz`

------
https://chatgpt.com/codex/tasks/task_e_6852a0461b888321b02ede4f142b37ad