### PR TITLE
Implement env-based time limit setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 *.out
 .DS_Store
 backend/.env
+frontend/.env

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ go run ./cmd/intro-quiz
 バックエンドを起動する前に `backend/.env.example` を `backend/.env` にコピーし、
 `YOUTUBE_API_KEY` などの値を適切に設定してください。`docker-compose.yml` も
 このファイルを利用します。
+フロントエンドも `frontend/env.example` を `frontend/.env` にコピーしてから起動し
+ます。こちらも `docker-compose.yml` で利用され、`VITE_TIME_LIMIT` とバックエンド
+側の `TIME_LIMIT` を同じ値に設定すると、クイズの制限時間を簡単に変更できます。
 
 ### Docker での実行
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables for the Intro-Quiz backend
 YOUTUBE_API_KEY=your_api_key_here
 PORT=8080
+TIME_LIMIT=10

--- a/backend/internal/config/env.go
+++ b/backend/internal/config/env.go
@@ -2,13 +2,23 @@ package config
 
 import (
 	"log"
+	"os"
+	"strconv"
 
 	"github.com/joho/godotenv"
 )
+
+// TimeLimit defines the countdown duration in seconds.
+var TimeLimit = 10
 
 // LoadEnv loads environment variables from a .env file.
 func LoadEnv() {
 	if err := godotenv.Load(); err != nil {
 		log.Println("no .env file found")
+	}
+	if v := os.Getenv("TIME_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			TimeLimit = n
+		}
 	}
 }

--- a/backend/internal/service/room.go
+++ b/backend/internal/service/room.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"intro-quiz/backend/internal/config"
 	"intro-quiz/backend/internal/model"
 )
 
@@ -136,7 +137,7 @@ func (m *RoomManager) StartQuestion(roomID string) {
 	m.mu.Unlock()
 
 	go func() {
-		time.Sleep(10 * time.Second)
+		time.Sleep(time.Duration(config.TimeLimit) * time.Second)
 		m.mu.Lock()
 		st := m.states[roomID]
 		if st != nil && st.Active && st.Fastest == "" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   frontend:
     build:
       context: ./frontend
+    env_file:
+      - ./frontend/.env
     ports:
       - "80:80"
   backend:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,7 @@
 FROM node:18-alpine AS build
 WORKDIR /app
 COPY package.json vite.config.js index.html ./
+COPY .env ./
 COPY src ./src
 RUN npm install
 RUN npm run build

--- a/frontend/env.example
+++ b/frontend/env.example
@@ -1,0 +1,2 @@
+VITE_WS_URL=ws://localhost:8080/ws
+VITE_TIME_LIMIT=10

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -5,6 +5,8 @@ import useWebSocket from "../hooks/useWebSocket";
 import { WS_URL } from "../services/websocket";
 import YouTubePlayer from "../components/YouTubePlayer";
 
+const TIME_LIMIT = parseInt(import.meta.env.VITE_TIME_LIMIT) || 10;
+
 export default function RoomPage() {
   const addMessage = useRoomStore((state) => state.addMessage);
   const clearMessages = useRoomStore((state) => state.clearMessages);
@@ -37,7 +39,7 @@ export default function RoomPage() {
           setWinner(null);
           setPauseInfo("");
           setPlaying(true);
-          setTimeLeft(10);
+          setTimeLeft(TIME_LIMIT);
           if (timerRef.current) clearInterval(timerRef.current);
           timerRef.current = setInterval(() => {
             setTimeLeft((t) => (t > 0 ? t - 1 : 0));


### PR DESCRIPTION
## Summary
- load quiz time limit from env in Go backend
- use environment variable in frontend for countdown
- provide env.example files and ignore frontend/.env
- document how to use the new env variables
- Docker compose now loads `frontend/.env`

## Testing
- `go vet ./...`
- `go test ./...`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852a354769c8321a4ae375cce2a2e53