### PR TITLE
Fix YouTube readiness and timer

### DIFF
--- a/frontend/src/components/YouTubePlayer.jsx
+++ b/frontend/src/components/YouTubePlayer.jsx
@@ -1,7 +1,12 @@
 import YouTube from "react-youtube";
 import { useEffect, useRef, useState } from "react";
 
-export default function YouTubePlayer({ videoId, playing, onPause }) {
+export default function YouTubePlayer({
+  videoId,
+  playing,
+  onPause,
+  onPlayerReady,
+}) {
   const playerRef = useRef(null);
   const [ready, setReady] = useState(false);
 
@@ -17,7 +22,15 @@ export default function YouTubePlayer({ videoId, playing, onPause }) {
   const onReady = (event) => {
     playerRef.current = event.target;
     setReady(true);
+    if (onPlayerReady) {
+      onPlayerReady();
+    }
   };
+
+  useEffect(() => {
+    setReady(false);
+    playerRef.current = null;
+  }, [videoId]);
 
   useEffect(() => {
     if (ready) {


### PR DESCRIPTION
## Summary
- ensure YouTube player only plays after ready
- disable Ready button until player is loaded
- restart countdown timer on each question

## Testing
- `npm install` in `frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852a918e6fc8321b688f21dc2d20ac6