### PR TITLE
Fix YouTube iframe origin and enable HTTPS dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ npm install
 npm run dev
 ```
 
-ブラウザで `http://localhost:5173` を開きます。
+ブラウザで `https://localhost:5173` を開きます。
+
+開発時は Vite を HTTPS で起動するため、自己署名証明書の作成を推奨します。
+`mkcert` などを利用して証明書を生成し、ブラウザに信頼させてください。
 
 ### バックエンド
 

--- a/frontend/src/components/YouTubePlayer.jsx
+++ b/frontend/src/components/YouTubePlayer.jsx
@@ -16,6 +16,8 @@ export default function YouTubePlayer({
     playerVars: {
       modestbranding: 1,
       rel: 0,
+      // Specify origin so that the YouTube iframe matches the current host
+      origin: window.location.origin,
     },
   };
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,5 +2,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  server: {
+    https: true,
+  },
 })


### PR DESCRIPTION
## Summary
- pass `origin` to YouTube iframe so the host matches
- run Vite dev server with HTTPS
- update README instructions for HTTPS

## Testing
- `npm run build`
- `go build ./cmd/intro-quiz`

------
https://chatgpt.com/codex/tasks/task_e_6852ae299d588321837fa9292a57acc9