### PR TITLE
Add buzz order queue

### DIFF
--- a/backend/internal/model/wsmessage.go
+++ b/backend/internal/model/wsmessage.go
@@ -14,4 +14,5 @@ type ServerMessage struct {
 	Timestamp  int64           `json:"timestamp"`
 	ReadyUsers map[string]bool `json:"readyUsers,omitempty"`
 	VideoID    string          `json:"videoId,omitempty"`
+	BuzzOrder  []string        `json:"buzzOrder,omitempty"`
 }

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -51,7 +51,6 @@ export default function RoomPage() {
           }, 1000);
         } else if (data.type === "buzz_result") {
           setWinner(data.user);
-          setQuestionActive(false);
           setPlaying(false);
           clearInterval(timerRef.current);
         } else if (data.type === "timeout") {

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -17,6 +17,8 @@ export default function RoomPage() {
   const messages = useRoomStore((state) => state.messages);
   const readyStates = useRoomStore((state) => state.readyStates);
   const setReadyStates = useRoomStore((state) => state.setReadyStates);
+  const buzzOrder = useRoomStore((state) => state.buzzOrder);
+  const setBuzzOrder = useRoomStore((state) => state.setBuzzOrder);
   const [joined, setJoined] = useState(false);
   const [name, setName] = useState("");
   const [roomId, setRoomId] = useState("");
@@ -42,6 +44,7 @@ export default function RoomPage() {
           setPauseInfo("");
           setPlaying(true);
           setTimeLeft(TIME_LIMIT);
+          setBuzzOrder([]);
           if (timerRef.current) clearInterval(timerRef.current);
           timerRef.current = setInterval(() => {
             setTimeLeft((t) => (t > 0 ? t - 1 : 0));
@@ -61,6 +64,8 @@ export default function RoomPage() {
           setPauseInfo(`${data.user}さんが解答ボタンを押しました - 再生停止中`);
         } else if (data.type === "ready_state") {
           setReadyStates(data.readyUsers);
+        } else if (data.type === "buzz_order") {
+          setBuzzOrder(data.buzzOrder);
         } else if (data.type === "video") {
           setVideoId(data.videoId);
         }
@@ -126,6 +131,16 @@ export default function RoomPage() {
             </div>
           )}
           {winner && <p>{winner}さんが解答権を獲得しました</p>}
+          {buzzOrder.length > 0 && (
+            <div>
+              <p>押した順:</p>
+              <ol>
+                {buzzOrder.map((u, idx) => (
+                  <li key={idx}>{u}</li>
+                ))}
+              </ol>
+            </div>
+          )}
           <ul>
             {messages.map((msg, i) => (
               <li key={i}>{msg}</li>

--- a/frontend/src/stores/roomStore.js
+++ b/frontend/src/stores/roomStore.js
@@ -10,4 +10,6 @@ export const useRoomStore = create((set) => ({
   setWinner: (name) => set({ winner: name }),
   readyStates: {},
   setReadyStates: (states) => set({ readyStates: states }),
+  buzzOrder: [],
+  setBuzzOrder: (order) => set({ buzzOrder: order }),
 }));


### PR DESCRIPTION
## Summary
- keep track of buzz order on the server
- broadcast the order to clients and store it in Zustand
- show the order list on the room page

## Testing
- `go vet ./...`
- `go build ./...`
- `npm install --no-audit --no-fund`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685671c31fd483218ea62472e53aa072