### PR TITLE
Implement answer submission and video info handling

### DIFF
--- a/backend/internal/model/wsmessage.go
+++ b/backend/internal/model/wsmessage.go
@@ -5,6 +5,7 @@ type ClientMessage struct {
 	Type       string `json:"type"`
 	User       string `json:"user,omitempty"`
 	PlaylistID string `json:"playlistId,omitempty"`
+	Answer     string `json:"answer,omitempty"`
 }
 
 // ServerMessage represents a message sent to clients.
@@ -15,4 +16,6 @@ type ServerMessage struct {
 	ReadyUsers map[string]bool `json:"readyUsers,omitempty"`
 	VideoID    string          `json:"videoId,omitempty"`
 	BuzzOrder  []string        `json:"buzzOrder,omitempty"`
+	VideoTitle string          `json:"videoTitle,omitempty"`
+	Correct    bool            `json:"correct,omitempty"`
 }

--- a/backend/internal/service/youtube.go
+++ b/backend/internal/service/youtube.go
@@ -72,25 +72,26 @@ func (s *YouTubeService) GetFirstVideoID(playlistID string) (string, error) {
 	return data.Items[0].Snippet.ResourceID.VideoID, nil
 }
 
-// GetRandomVideoID returns a random video's ID from the given playlist.
-func (s *YouTubeService) GetRandomVideoID(playlistID string) (string, error) {
+// GetRandomVideo returns a random video's ID and title from the given playlist.
+func (s *YouTubeService) GetRandomVideo(playlistID string) (string, string, error) {
 	url := fmt.Sprintf("https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId=%s&key=%s", playlistID, s.APIKey)
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("youtube api status: %s", resp.Status)
+		return "", "", fmt.Errorf("youtube api status: %s", resp.Status)
 	}
 	var data playlistItemsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return "", err
+		return "", "", err
 	}
 	if len(data.Items) == 0 {
-		return "", fmt.Errorf("no items found")
+		return "", "", fmt.Errorf("no items found")
 	}
 	rand.Seed(time.Now().UnixNano())
 	idx := rand.Intn(len(data.Items))
-	return data.Items[idx].Snippet.ResourceID.VideoID, nil
+	item := data.Items[idx].Snippet
+	return item.ResourceID.VideoID, item.Title, nil
 }

--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -27,6 +27,7 @@ export default function RoomPage() {
   const [pauseInfo, setPauseInfo] = useState("");
   const [videoId, setVideoId] = useState("M7lc1UVf-VE");
   const [playlistInput, setPlaylistInput] = useState("");
+  const [answerText, setAnswerText] = useState("");
   const timerRef = useRef(null);
   const { connect, send } = useWebSocket(WS_URL);
 
@@ -61,6 +62,15 @@ export default function RoomPage() {
         } else if (data.type === "answer") {
           setPlaying(false);
           setPauseInfo(`${data.user}さんが解答ボタンを押しました - 再生停止中`);
+        } else if (data.type === "answer_result") {
+          if (data.correct) {
+            setQuestionActive(false);
+            setWinner(null);
+            setPauseInfo(`${data.user}さんの正解！ 正解は${data.videoTitle}`);
+          } else {
+            setPauseInfo(`${data.user}さんは不正解`);
+            setWinner(null);
+          }
         } else if (data.type === "ready_state") {
           setReadyStates(data.readyUsers);
         } else if (data.type === "buzz_order") {
@@ -92,6 +102,13 @@ export default function RoomPage() {
 
   const sendReady = () => {
     send(JSON.stringify({ type: "ready", user: name }));
+  };
+
+  const sendAnswer = () => {
+    send(
+      JSON.stringify({ type: "answer_text", user: name, answer: answerText }),
+    );
+    setAnswerText("");
   };
 
   useEffect(() => {
@@ -130,6 +147,16 @@ export default function RoomPage() {
             </div>
           )}
           {winner && <p>{winner}さんが解答権を獲得しました</p>}
+          {winner === name && (
+            <div>
+              <input
+                placeholder="回答を入力"
+                value={answerText}
+                onChange={(e) => setAnswerText(e.target.value)}
+              />
+              <button onClick={sendAnswer}>送信</button>
+            </div>
+          )}
           {buzzOrder.length > 0 && (
             <div>
               <p>押した順:</p>


### PR DESCRIPTION
## Summary
- rename `GetRandomVideoID` to `GetRandomVideo` and return title too
- store video title in room state and check answers
- handle answer submissions and broadcast results
- show answer input on the client for the active player

## Testing
- `go vet ./...`
- `npx prettier --write frontend/src/pages/RoomPage.jsx`

------
https://chatgpt.com/codex/tasks/task_e_685685df30348321a26aacacfaf279fb