### PR TITLE
Add embeddable check

### DIFF
--- a/backend/cmd/intro-quiz/main.go
+++ b/backend/cmd/intro-quiz/main.go
@@ -22,9 +22,10 @@ func main() {
 
 	docs.SwaggerInfo.BasePath = "/"
 
-	router.GET("/ws", handler.WSHandler)
-	router.GET("/api/youtube/test", handler.YouTubeTestHandler)
-	router.GET("/api/hello", handler.HelloHandler)
+       router.GET("/ws", handler.WSHandler)
+       router.GET("/api/youtube/test", handler.YouTubeTestHandler)
+       router.GET("/api/youtube/embeddable/:videoId", handler.CheckEmbeddableHandler)
+       router.GET("/api/hello", handler.HelloHandler)
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	log.Println("Listening on :8080")

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -38,6 +38,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/youtube/embeddable/{videoId}": {
+            "get": {
+                "description": "Verify the embeddable status of a YouTube video.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "youtube"
+                ],
+                "summary": "Check if video is embeddable",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "YouTube video ID",
+                        "name": "videoId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/youtube/test": {
             "get": {
                 "description": "Retrieve the first video's title from a fixed YouTube playlist.",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -31,6 +31,56 @@
                 }
             }
         },
+        "/api/youtube/embeddable/{videoId}": {
+            "get": {
+                "description": "Verify the embeddable status of a YouTube video.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "youtube"
+                ],
+                "summary": "Check if video is embeddable",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "YouTube video ID",
+                        "name": "videoId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/youtube/test": {
             "get": {
                 "description": "Retrieve the first video's title from a fixed YouTube playlist.",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -20,6 +20,39 @@ paths:
       summary: Say hello
       tags:
       - example
+  /api/youtube/embeddable/{videoId}:
+    get:
+      description: Verify the embeddable status of a YouTube video.
+      parameters:
+      - description: YouTube video ID
+        in: path
+        name: videoId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: boolean
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Check if video is embeddable
+      tags:
+      - youtube
   /api/youtube/test:
     get:
       description: Retrieve the first video's title from a fixed YouTube playlist.

--- a/backend/internal/handler/youtube.go
+++ b/backend/internal/handler/youtube.go
@@ -26,3 +26,27 @@ func YouTubeTestHandler(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "title": title})
 }
+
+// CheckEmbeddableHandler reports whether a video can be embedded.
+// @Summary      Check if video is embeddable
+// @Description  Verify the embeddable status of a YouTube video.
+// @Tags         youtube
+// @Produce      json
+// @Param        videoId   path      string  true  "YouTube video ID"
+// @Success      200 {object} map[string]bool
+// @Failure      400 {object} map[string]string
+// @Failure      500 {object} map[string]string
+// @Router       /api/youtube/embeddable/{videoId} [get]
+func CheckEmbeddableHandler(c *gin.Context) {
+       videoID := c.Param("videoId")
+       if videoID == "" {
+               c.JSON(http.StatusBadRequest, gin.H{"error": "videoId required"})
+               return
+       }
+       ok, err := service.CheckEmbeddable(videoID)
+       if err != nil {
+               c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": err.Error()})
+               return
+       }
+       c.JSON(http.StatusOK, gin.H{"embeddable": ok})
+}


### PR DESCRIPTION
## Summary
- detect if a YouTube video can be embedded using `videos.list`
- expose `/api/youtube/embeddable/{videoId}` for checking embed ability
- update swagger docs for the new endpoint

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858a43c9bb88321972b3ab1420e78ac