### PR TITLE
Fix playlist randomization

### DIFF
--- a/backend/internal/service/youtube.go
+++ b/backend/internal/service/youtube.go
@@ -21,7 +21,8 @@ func NewYouTubeService(key string) *YouTubeService {
 
 // playlistItemsResponse represents a subset of the YouTube API response.
 type playlistItemsResponse struct {
-	Items []struct {
+	NextPageToken string `json:"nextPageToken"`
+	Items         []struct {
 		Snippet struct {
 			Title      string `json:"title"`
 			ResourceID struct {
@@ -29,6 +30,12 @@ type playlistItemsResponse struct {
 			} `json:"resourceId"`
 		} `json:"snippet"`
 	} `json:"items"`
+}
+
+// VideoItem represents a single video ID and title pair.
+type VideoItem struct {
+	ID    string
+	Title string
 }
 
 // GetFirstVideoTitle returns the first video's title from the given playlist.
@@ -71,6 +78,35 @@ func (s *YouTubeService) GetFirstVideoID(playlistID string) (string, error) {
 		return "", fmt.Errorf("no items found")
 	}
 	return data.Items[0].Snippet.ResourceID.VideoID, nil
+}
+
+// ListPlaylistVideos retrieves all video IDs and titles from the playlist.
+func (s *YouTubeService) ListPlaylistVideos(playlistID string) ([]VideoItem, error) {
+	var videos []VideoItem
+	pageToken := ""
+	for {
+		url := fmt.Sprintf("https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId=%s&key=%s&pageToken=%s", playlistID, s.APIKey, pageToken)
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("youtube api status: %s", resp.Status)
+		}
+		var data playlistItemsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, err
+		}
+		for _, it := range data.Items {
+			videos = append(videos, VideoItem{ID: it.Snippet.ResourceID.VideoID, Title: it.Snippet.Title})
+		}
+		if data.NextPageToken == "" {
+			break
+		}
+		pageToken = data.NextPageToken
+	}
+	return videos, nil
 }
 
 // GetRandomVideo returns a random video's ID and title from the given playlist.


### PR DESCRIPTION
## Summary
- avoid playing the same song repeatedly by keeping a remaining playlist
- fetch entire playlist when a playlist is set
- pick videos at random from remaining list and check if embeddable

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_685d8827bfac83219a10c52456f80ea1