### PR TITLE
Implement answer-right based logic

### DIFF
--- a/frontend/src/pages/RoomPage.jsx
+++ b/frontend/src/pages/RoomPage.jsx
@@ -17,8 +17,6 @@ export default function RoomPage() {
   const messages = useRoomStore((state) => state.messages);
   const readyStates = useRoomStore((state) => state.readyStates);
   const setReadyStates = useRoomStore((state) => state.setReadyStates);
-  const buzzOrder = useRoomStore((state) => state.buzzOrder);
-  const setBuzzOrder = useRoomStore((state) => state.setBuzzOrder);
   const [joined, setJoined] = useState(false);
   const [name, setName] = useState("");
   const [roomId, setRoomId] = useState("");
@@ -45,7 +43,6 @@ export default function RoomPage() {
           setPauseInfo("");
           setPlaying(true);
           setTimeLeft(TIME_LIMIT);
-          setBuzzOrder([]);
           if (timerRef.current) clearInterval(timerRef.current);
           timerRef.current = setInterval(() => {
             setTimeLeft((t) => (t > 0 ? t - 1 : 0));
@@ -73,8 +70,14 @@ export default function RoomPage() {
           }
         } else if (data.type === "ready_state") {
           setReadyStates(data.readyUsers);
-        } else if (data.type === "buzz_order") {
-          setBuzzOrder(data.buzzOrder);
+        } else if (data.type === "resume") {
+          setPlaying(true);
+          setPauseInfo("");
+          setQuestionActive(true);
+          if (timerRef.current) clearInterval(timerRef.current);
+          timerRef.current = setInterval(() => {
+            setTimeLeft((t) => (t > 0 ? t - 1 : 0));
+          }, 1000);
         } else if (data.type === "video") {
           setVideoId(data.videoId);
         }
@@ -155,16 +158,6 @@ export default function RoomPage() {
                 onChange={(e) => setAnswerText(e.target.value)}
               />
               <button onClick={sendAnswer}>送信</button>
-            </div>
-          )}
-          {buzzOrder.length > 0 && (
-            <div>
-              <p>押した順:</p>
-              <ol>
-                {buzzOrder.map((u, idx) => (
-                  <li key={idx}>{u}</li>
-                ))}
-              </ol>
             </div>
           )}
           <ul>

--- a/frontend/src/stores/roomStore.js
+++ b/frontend/src/stores/roomStore.js
@@ -10,6 +10,4 @@ export const useRoomStore = create((set) => ({
   setWinner: (name) => set({ winner: name }),
   readyStates: {},
   setReadyStates: (states) => set({ readyStates: states }),
-  buzzOrder: [],
-  setBuzzOrder: (order) => set({ buzzOrder: order }),
 }));


### PR DESCRIPTION
## Summary
- manage per-question answer rights and timer
- restart playback after wrong answers
- simplify frontend by removing buzz order

## Testing
- `npm run build`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e4215211083219feda96f990abd90